### PR TITLE
Add wasm32-unknown-unknown before building target

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -9,6 +9,7 @@ The resulting .wasm file is going to be used by the Gecko profiler.
 
 ```bash
 $ rustup default nightly
+$ rustup target add wasm32-unknown-unknown
 $ cargo build --target wasm32-unknown-unknown --release
 $ wasm-bindgen target/wasm32-unknown-unknown/release/profiler_get_symbols.wasm --out-dir . --no-modules --no-typescript
 $ cp profiler_get_symbols_bg.wasm `shasum -b -a 384 profiler_get_symbols_bg.wasm | awk '{ print $1 }'`.wasm


### PR DESCRIPTION
The `wasm32-unknown-unknown` target needs to be installed before building target, otherwise run into crate build errors.