### PR TITLE
wasm-bindgen-cli needs to be installed to build

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -10,6 +10,7 @@ The resulting .wasm file is going to be used by the Gecko profiler.
 ```bash
 $ rustup default nightly
 $ cargo build --target wasm32-unknown-unknown --release
+$ cargo install wasm-bindgen-cli
 $ wasm-bindgen target/wasm32-unknown-unknown/release/profiler_get_symbols.wasm --out-dir . --no-modules --no-typescript
 $ cp profiler_get_symbols_bg.wasm `shasum -b -a 384 profiler_get_symbols_bg.wasm | awk '{ print $1 }'`.wasm
 $ shasum -b -a 384 profiler_get_symbols_bg.wasm | awk '{ print $1 }' | xxd -r -p | base64 # This is your SRI hash


### PR DESCRIPTION
Installing `wasm-bindgen-cli` to build. `wasm-bindgen-cli` adds `wasm-bindgen` to PATH, so it becomes a terminal command.

Adds after changes to #3