### PR TITLE
Implement partial PDB reading.

### DIFF
--- a/lib/src/macho.rs
+++ b/lib/src/macho.rs
@@ -110,7 +110,7 @@ where
         while let Some(obj_ref) = remainder.pop_front() {
             let path = obj_ref.path();
             let file_contents = match helper.open_file(path).await {
-                Ok(data) => FileContentsWrapper(data),
+                Ok(data) => FileContentsWrapper::new(data),
                 Err(_) => {
                     // We probably couldn't find the file, but that's fine.
                     // It would be good to collect this error somewhere.


### PR DESCRIPTION
Unfortunately this saves almost nothing. It skips around 20MB of the 1GB xul.pdb in the win64-ci benchmark.