### PR TITLE
Use u64 instead of usize in the FileContents trait.

### DIFF
--- a/examples/dump_table/src/lib.rs
+++ b/examples/dump_table/src/lib.rs
@@ -76,17 +76,13 @@ struct MmapFileContents(memmap::Mmap);
 
 impl FileContents for MmapFileContents {
     #[inline]
-    fn len(&self) -> usize {
-        self.0.len()
+    fn len(&self) -> u64 {
+        self.0.len() as u64
     }
 
     #[inline]
-    fn read_bytes_at<'a>(
-        &'a self,
-        offset: usize,
-        size: usize,
-    ) -> FileAndPathHelperResult<&'a [u8]> {
-        Ok(&self.0[offset..][..size])
+    fn read_bytes_at<'a>(&'a self, offset: u64, size: u64) -> FileAndPathHelperResult<&'a [u8]> {
+        Ok(&self.0[offset as usize..][..size as usize])
     }
 }
 

--- a/examples/query_api/src/lib.rs
+++ b/examples/query_api/src/lib.rs
@@ -15,17 +15,13 @@ struct MmapFileContents(memmap::Mmap);
 
 impl FileContents for MmapFileContents {
     #[inline]
-    fn len(&self) -> usize {
-        self.0.len()
+    fn len(&self) -> u64 {
+        self.0.len() as u64
     }
 
     #[inline]
-    fn read_bytes_at<'a>(
-        &'a self,
-        offset: usize,
-        size: usize,
-    ) -> FileAndPathHelperResult<&'a [u8]> {
-        Ok(&self.0[offset..][..size])
+    fn read_bytes_at<'a>(&'a self, offset: u64, size: u64) -> FileAndPathHelperResult<&'a [u8]> {
+        Ok(&self.0[offset as usize..][..size as usize])
     }
 }
 struct Helper {

--- a/lib/src/pdb/mod.rs
+++ b/lib/src/pdb/mod.rs
@@ -391,7 +391,7 @@ impl<'s, F: FileContents> pdb::Source<'s> for &'s FileContentsWrapper<F> {
             let mut output_offset: usize = 0;
             for slice in slices {
                 let slice_buf = self
-                    .read_bytes_at(slice.offset as usize, slice.size)
+                    .read_bytes_at(slice.offset, slice.size as u64)
                     .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
                 bytes[output_offset..(output_offset + slice.size)].copy_from_slice(slice_buf);
                 output_offset += slice.size;

--- a/lib/src/shared.rs
+++ b/lib/src/shared.rs
@@ -8,9 +8,8 @@ pub type FileAndPathHelperError = Box<dyn std::error::Error + Send + Sync + 'sta
 pub type FileAndPathHelperResult<T> = std::result::Result<T, FileAndPathHelperError>;
 
 pub trait FileContents {
-    fn len(&self) -> usize;
-    fn read_bytes_at<'a>(&'a self, offset: usize, size: usize)
-        -> FileAndPathHelperResult<&'a [u8]>;
+    fn len(&self) -> u64;
+    fn read_bytes_at<'a>(&'a self, offset: u64, size: u64) -> FileAndPathHelperResult<&'a [u8]>;
 }
 
 // Define a OptionallySendFuture trait. This exists for the following reasons:
@@ -125,8 +124,8 @@ where
 
 pub struct FileContentsWrapper<T: FileContents> {
     file_contents: T,
-    len: usize,
-    bytes_read: Cell<usize>,
+    len: u64,
+    bytes_read: Cell<u64>,
 }
 
 impl<T: FileContents> FileContentsWrapper<T> {
@@ -140,15 +139,15 @@ impl<T: FileContents> FileContentsWrapper<T> {
     }
 
     #[inline]
-    pub fn len(&self) -> usize {
+    pub fn len(&self) -> u64 {
         self.len
     }
 
     #[inline]
     pub fn read_bytes_at<'a>(
         &'a self,
-        offset: usize,
-        size: usize,
+        offset: u64,
+        size: u64,
     ) -> FileAndPathHelperResult<&'a [u8]> {
         self.bytes_read.set(self.bytes_read.get() + size);
         self.file_contents.read_bytes_at(offset, size)
@@ -158,7 +157,7 @@ impl<T: FileContents> FileContentsWrapper<T> {
         self.read_bytes_at(0, self.len())
     }
 
-    pub fn bytes_read(&self) -> usize {
+    pub fn bytes_read(&self) -> u64 {
         self.bytes_read.get()
     }
 }

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -164,20 +164,20 @@ async fn get_compact_symbol_table_impl(
 
 pub struct FileHandle {
     contents: FileContents,
-    cache: RefCell<HashMap<(usize, usize), Box<[u8]>>>,
+    cache: RefCell<HashMap<(u64, u64), Box<[u8]>>>,
 }
 
 impl profiler_get_symbols::FileContents for FileHandle {
     #[inline]
-    fn len(&self) -> usize {
-        self.contents.getLength() as usize
+    fn len(&self) -> u64 {
+        self.contents.getLength() as u64
     }
 
     #[inline]
     fn read_bytes_at<'a>(
         &'a self,
-        offset: usize,
-        size: usize,
+        offset: u64,
+        size: u64,
     ) -> profiler_get_symbols::FileAndPathHelperResult<&'a [u8]> {
         let cache = &mut *self.cache.borrow_mut();
         let buf = cache.entry((offset, size)).or_insert_with(|| {


### PR DESCRIPTION
This is what the proposed object ReadRef uses. And it theoretically lets us parse >4GB objects in wasm32.